### PR TITLE
Fix services script

### DIFF
--- a/services
+++ b/services
@@ -46,7 +46,7 @@ waitForKeyrock () {
 waitForSecureKeyrock () {
 	echo -e "⏳ Waiting for \033[1;31mKeyrock\033[0m to be available\n"
 	
-	while [ `curl -k -s -o /dev/null -w %{http_code} 'https://localhost:3443/version'` -eq 000 ]
+	while [ `curl -k -s -o /dev/null -w %{http_code} 'https://localhost:3443/version'` -eq 000` ]
 	do 
 		echo -e "Keyrock HTTP state: " `curl -k -s -o /dev/null -w %{http_code} 'https://localhost:3443/version'` " (waiting for 200)"
 		sleep 5


### PR DESCRIPTION
While following the tutorial [IDENTITY MANAGEMENT](https://fiware-tutorials.readthedocs.io/en/latest/identity-management/index.html)

After execution of:
`./services create`

I got the following error:
`./services: line 51: unexpected EOF while looking for matching ``'`

The actual problem was at line **49** where curl request didn't have the closing backtick (**`**)